### PR TITLE
Added a `dunion` macro, which acts as a union with the next field.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ It is unnecessary to put a label right before `dstruct`, since a label is declar
 
 Two extra constants are declared, that mirror the struct's: `sizeof_Player` would be equal to `sizeof_NPC`, and `Player_nb_fields` would equal `NPC_nb_fields`. These constants will keep their values even if the originals, such as `sizeof_NPC`, are `PURGE`'d.
 
+## Declaring a union
+
+Unions are simply an alias for the following field. To define a union, use `dunion UnionName`.
+
+```
+    ; Flags and Data will point to the same field
+    dunion Flags
+    bytes 1, Data
+```
+
+This is not possible:
+```
+    dunion words 1 VectorPos
+    bytes 1 XPos
+    bytes 1 YPos
+```
+However, `dunion VectorPos` will have the same effect.
+
 
 
 # Credits

--- a/structs.asm
+++ b/structs.asm
@@ -173,6 +173,42 @@ STRUCT_FIELD_TYPE equs STRSUB("\2", 2, 1)
 NB_FIELDS = NB_FIELDS + 1
 ENDM
 
+; dunion union_name
+; Defines an Alias for the next field
+dunion: MACRO
+    IF !DEF(STRUCT_NAME) || !DEF(NB_FIELDS)
+        FAIL "Please start defining a struct, using `define_struct`"
+    ENDC
+
+    get_nth_field_info NB_FIELDS
+    ; Set field name (keep in mind `STRUCT_FIELD_NAME` is *itself* an EQUS!)
+STRUCT_FIELD_NAME equs "\"\1\""
+    PURGE STRUCT_FIELD_NAME
+
+    ; Set field offset
+STRUCT_FIELD RB 0
+    ; Alias this in a human-comprehensive manner
+STRUCT_FIELD_NAME equs "{STRUCT_NAME}_\1"
+STRUCT_FIELD_NAME = STRUCT_FIELD
+
+    ; Compute field size
+CURRENT_RS RB 0
+STRUCT_FIELD_SIZE = CURRENT_RS - STRUCT_FIELD
+
+    ; Set properties
+STRUCT_FIELD_NBEL = 0
+STRUCT_FIELD_TYPE equs STRSUB("RB", 2, 1)
+
+    PURGE STRUCT_FIELD
+    PURGE STRUCT_FIELD_NAME
+    PURGE STRUCT_FIELD_TYPE
+    PURGE STRUCT_FIELD_NBEL
+    PURGE STRUCT_FIELD_SIZE
+    PURGE CURRENT_RS
+
+NB_FIELDS = NB_FIELDS + 1
+ENDM
+
 ; bytes nb_bytes, field_name
 ; Defines a field of N bytes
 bytes: MACRO


### PR DESCRIPTION
All you need to do is type `dunion` before a field, which reuses `new_field` but doesn't allocate any new space.