### PR TITLE
Fix and simplify RGBDS-structs using RGBDS 0.5.1 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # RGBDS structs
 
 An attempt at using macros to add struct-like functionality to RGBDS.
@@ -14,7 +13,7 @@ An attempt at using macros to add struct-like functionality to RGBDS.
 
 This doesn't actually require any installing, only to `INCLUDE` the file `structs.asm` in your project. Examples can be found in the `examples` folder. This project is licensed under the MIT license.
 
-This is confirmed to work with RGBDS 0.3.7, but should also work with versions 0.3.3 and newer. If you find a compatibility issue, please file it [here](https://github.com/ISSOtm/rgbds-structs/issues/new).
+The latest RGBDS-structs version is **2.0.0**. It will only work with RGBDS 0.5.1 and newer. The previous version, 1.3.0, is confirmed to work with RGBDS 0.3.7, but should also work with versions 0.3.3 and newer. If you find a compatibility issue, please file it [here](https://github.com/ISSOtm/rgbds-structs/issues/new).
 
 
 # Usage
@@ -23,7 +22,7 @@ This is confirmed to work with RGBDS 0.3.7, but should also work with versions 0
 
 Begin the declaration with `struct StructName`. This need not be in a `SECTION`, and it is rather recommended to declare structs in header files, as with C.
 
-Then, declare each member; the declaration style is inspired by RGBDS' `_RS` command group: the macro name is the field type, the first argument dictates how many units the argument uses, and the second argument gives the field name.
+Then, declare each member. The declaration style is inspired by RGBDS' `_RS` command group: the macro name is the field type, the first argument dictates how many units the argument uses, and the second argument gives the field name.
 
 Finally, you must close the declaration with `end_struct`. This is required to properly define all of the struct's variables, and to be able to declare another struct (which will otherwise fail with a descriptive error message). Please note that you can forget to add `end_struct` and not get any error messages, so please be careful.
 

--- a/examples/correct.asm
+++ b/examples/correct.asm
@@ -1,5 +1,8 @@
-
 INCLUDE "../structs.asm"
+
+    ; Check for the expected RGBDS-structs version
+    rgbds_structs_version 2.0.0
+
 
     ; Struct declarations (ideally in a separate file, but grouped here for simplicity)
     ; Note that everything is happening outside of a `SECTION`
@@ -14,7 +17,7 @@ INCLUDE "../structs.asm"
     end_struct
 
     ; Defines an NPC, as I used in Aevilia (https://github.com/ISSOtm/Aevilia-GB/blob/master/macros/memory.asm#L10-L25)
-    struct Sprite
+    struct NPC
         words 1, YPos
         words 1, XPos
         bytes 1, YBox
@@ -44,6 +47,8 @@ INCLUDE "../structs.asm"
 
 
 SECTION "Code", ROM0
+
+Routine::
 
     ; Using struct offsets
     ld de, wPlayer
@@ -76,16 +81,20 @@ SECTION "Code", ROM0
 
     ld hl, wOBJPalette0
     ld de, DefaultPalette
-    ld c, sizeof_wOBJPalette ; Using the variable's size
+    ld c, sizeof_wOBJPalette0 ; Using the variable's size
     call memcpy_small
 
     ; ...
 
-DefaultPalette:
-    db $00, $00, $00
-    db $0A, $0A, $0A
-    db $15, $15, $15
-    db $1F, $1F, $1F
+    ; Ordered instantiation of a struct passes each field in order
+    ; Multi-byte fields repeat the byte to fill their size
+    dstruct RawPalette, DefaultPalette, $00, $0A, $15, $1F
+
+    ; Named instantiation can be out of order
+    dstruct RawPalette, CustomPalette, \
+        .Color1=$1E\,$0A\,$06, \ ; Multi-byte fields can take a
+        .Color2=$1F\,$13\,$16, \ ; sequence of bytes to repeat
+        .Color3=$1F, .Color0=$00
 
 
 memcpy_small:


### PR DESCRIPTION
Fixes #4

Also fixes an unreported issue where detecting conflicting or invalid named fields passed to a `dstruct` wasn't working correctly.

Uses these rgbds 0.5.0 and 0.5.1 features:

- `DEF` allows variable assignments to be indented
- `FOR` loops are shorter than `REPT` with an explicit variable
- `BREAK` allows early exit from loops, and can avoid macro recursion
- `{Interpolation}` outside of string literals avoids temporary `EQUS`
- `REDEF` simplifies updating `EQUS` without having to `PURGE` a temporary
- `DS` with a sequence of bytes helps initialize multi-byte fields
- `STRRPL` replaces the `strreplace` macro
- Multi-arg `STRCAT` makes it easier to wrap long strings across lines
- `STRSUB` without a length argument reads to the end of a string
- `\<ARG_NUM>` makes `SHIFT`ing unnecessary