### PR TITLE
Fix version information, and use compound assignment operator

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Eldred Habert
+Copyright (c) 2018-2024 Eldred Habert and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please select a version from [the releases](https://github.com/ISSOtm/rgbds-stru
 (If you do not know what a `.tar.gz` file is, download the `.zip` one.)
 
 The [latest rgbds-structs version](https://github.com/ISSOtm/rgbds-structs/releases/latest) is **4.0.0**.
-It will only work with RGBDS 0.5.1 and newer.
+It will only work with RGBDS 0.5.2 and newer.
 A previous version, [1.3.0](https://github.com/ISSOtm/rgbds-structs/releases/tag/v1.3.0), is confirmed to work with RGBDS 0.3.7, but should also work with versions 0.3.3 and newer.
 If you find a compatibility issue, [please file it here](https://github.com/ISSOtm/rgbds-structs/issues/new).
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please select a version from [the releases](https://github.com/ISSOtm/rgbds-stru
 (If you do not know what a `.tar.gz` file is, download the `.zip` one.)
 
 The [latest rgbds-structs version](https://github.com/ISSOtm/rgbds-structs/releases/latest) is **4.0.0**.
-It will only work with RGBDS 0.5.2 and newer.
+It will only work with RGBDS 0.6.0 and newer.
 A previous version, [1.3.0](https://github.com/ISSOtm/rgbds-structs/releases/tag/v1.3.0), is confirmed to work with RGBDS 0.3.7, but should also work with versions 0.3.3 and newer.
 If you find a compatibility issue, [please file it here](https://github.com/ISSOtm/rgbds-structs/issues/new).
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [RGBDS](https://rgbds.gbdev.io) macro pack that provides `struct`-like functio
 Please select a version from [the releases](https://github.com/ISSOtm/rgbds-structs/releases), and download either of the "source code" links.
 (If you do not know what a `.tar.gz` file is, download the `.zip` one.)
 
-The [latest rgbds-structs version](https://github.com/ISSOtm/rgbds-structs/releases/latest) is **4.0.0**.
+The [latest rgbds-structs version](https://github.com/ISSOtm/rgbds-structs/releases/latest) is **4.0.1**.
 It will only work with RGBDS 0.6.0 and newer.
 A previous version, [1.3.0](https://github.com/ISSOtm/rgbds-structs/releases/tag/v1.3.0), is confirmed to work with RGBDS 0.3.7, but should also work with versions 0.3.3 and newer.
 If you find a compatibility issue, [please file it here](https://github.com/ISSOtm/rgbds-structs/issues/new).

--- a/examples/correct.asm
+++ b/examples/correct.asm
@@ -1,7 +1,7 @@
 INCLUDE "../structs.inc"
 
     ; Check for the expected RGBDS-structs version
-    rgbds_structs_version 4.0.0
+    rgbds_structs_version 4.0.1
 
 
     ; Struct declarations (ideally in a separate file, but grouped here for simplicity)

--- a/examples/correct.asm
+++ b/examples/correct.asm
@@ -1,7 +1,7 @@
 INCLUDE "../structs.inc"
 
     ; Check for the expected RGBDS-structs version
-    rgbds_structs_version 3.0.0
+    rgbds_structs_version 4.0.0
 
 
     ; Struct declarations (ideally in a separate file, but grouped here for simplicity)

--- a/structs.inc
+++ b/structs.inc
@@ -23,7 +23,7 @@
 
 
 
-DEF STRUCTS_VERSION equs "4.0.0"
+DEF STRUCTS_VERSION equs "4.0.1"
 MACRO structs_assert
     assert (\1), "rgbds-structs {STRUCTS_VERSION} bug. Please report at https://github.com/ISSOtm/rgbds-structs, and share the above stack trace *and* your code there!"
 ENDM

--- a/structs.inc
+++ b/structs.inc
@@ -300,7 +300,7 @@ MACRO dstruct ; struct_type, instance_name[, ...]
                     ENDC
                     d{{STRUCT_FIELD_TYPE}} {FIELD_INITIALIZER}
                     PURGE FIELD_INITIALIZER
-                    REDEF ARG_NUM = ARG_NUM + 1
+                    DEF ARG_NUM += 1
                 ENDC
                 ; Add padding as necessary after the provided initializer
                 ; (possibly all of it, especially for RAM use)

--- a/structs.inc
+++ b/structs.inc
@@ -1,6 +1,6 @@
 ; MIT License
 ;
-; Copyright (c) 2018-2022 Eldred Habert and contributors
+; Copyright (c) 2018-2024 Eldred Habert and contributors
 ; Originally hosted at https://github.com/ISSOtm/rgbds-structs
 ;
 ; Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
The `+=` operator was added in RGBDS 0.5.2 from November 2021 (https://github.com/gbdev/rgbds/pull/944). The `REDEF =` syntax it's currently using was added in RGBDS 0.5.0 from April 2021 (https://github.com/gbdev/rgbds/pull/791).

Also the parentheses-allow-commas behavior we just added in place of manually escaping `\,` was added in RGBDS 0.5.1 from May 2021 (https://github.com/gbdev/rgbds/pull/852). So this no longer supports 0.5.0 anyway.