### PR TITLE
Release 4.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [RGBDS](https://rgbds.gbdev.io) macro pack that provides `struct`-like functio
 Please select a version from [the releases](https://github.com/ISSOtm/rgbds-structs/releases), and download either of the "source code" links.
 (If you do not know what a `.tar.gz` file is, download the `.zip` one.)
 
-The [latest rgbds-structs version](https://github.com/ISSOtm/rgbds-structs/releases/latest) is **4.0.1**.
+The [latest rgbds-structs version](https://github.com/ISSOtm/rgbds-structs/releases/latest) is **4.0.2**.
 It will only work with RGBDS 0.6.0 and newer.
 A previous version, [1.3.0](https://github.com/ISSOtm/rgbds-structs/releases/tag/v1.3.0), is confirmed to work with RGBDS 0.3.7, but should also work with versions 0.3.3 and newer.
 If you find a compatibility issue, [please file it here](https://github.com/ISSOtm/rgbds-structs/issues/new).

--- a/examples/correct.asm
+++ b/examples/correct.asm
@@ -1,7 +1,7 @@
 INCLUDE "../structs.inc"
 
     ; Check for the expected RGBDS-structs version
-    rgbds_structs_version 4.0.1
+    rgbds_structs_version 4.0.2
 
 
     ; Struct declarations (ideally in a separate file, but grouped here for simplicity)

--- a/structs.inc
+++ b/structs.inc
@@ -23,7 +23,7 @@
 
 
 
-DEF STRUCTS_VERSION equs "4.0.1"
+DEF STRUCTS_VERSION equs "4.0.2"
 MACRO structs_assert
     assert (\1), "rgbds-structs {STRUCTS_VERSION} bug. Please report at https://github.com/ISSOtm/rgbds-structs, and share the above stack trace *and* your code there!"
 ENDM


### PR DESCRIPTION
RGBDS 0.9.0-rc2 is out, and this works with it.

Changes since rgbds-structs 4.0.1:

- Correct `STRUCTS_VERSION` (the 4.0.1 release declared itself as 4.0.0)