### PR TITLE
Release 4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ A [RGBDS](https://rgbds.gbdev.io) macro pack that provides `struct`-like functio
 Please select a version from [the releases](https://github.com/ISSOtm/rgbds-structs/releases), and download either of the "source code" links.
 (If you do not know what a `.tar.gz` file is, download the `.zip` one.)
 
-The [latest rgbds-structs version](https://github.com/ISSOtm/rgbds-structs/releases/latest) is **4.0.2**.
-It will only work with RGBDS 0.6.0 and newer.
-A previous version, [1.3.0](https://github.com/ISSOtm/rgbds-structs/releases/tag/v1.3.0), is confirmed to work with RGBDS 0.3.7, but should also work with versions 0.3.3 and newer.
+The [latest rgbds-structs version](https://github.com/ISSOtm/rgbds-structs/releases/latest) is **4.1.0**.
+It will only work with RGBDS 0.9.2 and newer.
+The previous version, [4.0.2](https://github.com/ISSOtm/rgbds-structs/releases/tag/v4.0.2), works with RGBDS 0.6.0 and newer.
+An older version, [1.3.0](https://github.com/ISSOtm/rgbds-structs/releases/tag/v1.3.0), is confirmed to work with RGBDS 0.3.7, but should also work with versions 0.3.3 and newer.
 If you find a compatibility issue, [please file it here](https://github.com/ISSOtm/rgbds-structs/issues/new).
 
 ## Installing
@@ -35,7 +36,7 @@ You can also easily enforce this in your code, using the `rgbds_structs_version`
 1. Begin the declaration with `struct StructName`.
    This need not be in a `SECTION`, and it is rather recommended to declare structs in header files, as with C.
 2. Then, declare each member, using the macros `bytes`, `words`, and `longs`.
-   The declaration style is inspired by [RGBASM's `_RS` command family](https://rgbds.gbdev.io/docs/v0.5.2/rgbasm.5/#Offset_constants): the macro name gives the unit type, the first argument specifies how many units the member uses, and the second argument gives the member name.
+   The declaration style is inspired by [RGBASM's `_RS` command family](https://rgbds.gbdev.io/docs/rgbasm.5#Offset_constants): the macro name gives the unit type, the first argument specifies how many units the member uses, and the second argument gives the member name.
 3. Finally, you must close the declaration with `end_struct`.
    This is required to properly define all of the struct's constants, and to be able to declare another struct (which will otherwise fail with a descriptive error message).
    Please note that forgetting to add an `end_struct` does not always yield any error messages, so please be careful.
@@ -45,25 +46,24 @@ Please do not use anything other than the prescribed macros between `struct` and
 Example of correct usage:
 
 ```asm
-    ; RGBASM requires whitespace before the macro name
-    struct NPC
-    words 1, YPos         ;  2 bytes
-    words 1, XPos         ;  2 bytes
-    bytes 1, YBox         ;  1 byte
-    bytes 1, XBox         ;  1 byte
-    bytes 6, Name         ;  6 bytes
-    longs 4, MovementData ; 16 bytes
-    end_struct
+struct NPC
+	words 1, YPos         ;  2 bytes
+	words 1, XPos         ;  2 bytes
+	bytes 1, YBox         ;  1 byte
+	bytes 1, XBox         ;  1 byte
+	bytes 6, Name         ;  6 bytes
+	longs 4, MovementData ; 16 bytes
+end_struct
 ```
 
 Note that no padding is inserted between members by rgbds-structs itself; insert "throwaway" members for that.
 
 ```asm
-    struct Example
-        bytes 3, First
-        bytes 1, Padding  ; like this
-        words 2, Second
-    end_struct
+struct Example
+	bytes 3, First
+	bytes 1, Padding  ; like this
+	words 2, Second
+end_struct
 ```
 
 (Some like to insert an extra level of indentation for member definitions. This is not required, but may help with readability.)
@@ -73,13 +73,13 @@ Note also that whitespace is **not** allowed in a struct or member's name.
 Sometimes it's useful to give multiple names to the same area of memory, which can be accomplished with `alias`.
 
 ```asm
-    struct Actor
-        words 1, YPos
-        words 1, XPos
-        ; Since `alias` is used, the following field will have 2 names
-        alias Money ; If this actor is the player, store how much money they have.
-        words 1, Target ; If this actor is an enemy, store their target actor.
-    end_struct
+struct Actor
+	words 1, YPos
+	words 1, XPos
+	; Since `alias` is used, the following field will have 2 names
+	alias Money ; If this actor is the player, store how much money they have.
+	words 1, Target ; If this actor is an enemy, store their target actor.
+end_struct
 ```
 
 Passing a size of 0 to any of `bytes`, `words`, or `longs` works the same.
@@ -87,16 +87,16 @@ Passing a size of 0 to any of `bytes`, `words`, or `longs` works the same.
 `extends` can be used to nest a structure within another.
 
 ```asm
-    struct Item
-        words 1, Name
-        words 1, Graphics
-        bytes 1, Type
-    end_struct
+struct Item
+	words 1, Name
+	words 1, Graphics
+	bytes 1, Type
+end_struct
 
-    struct HealingItem
-        extends Item
-        bytes Strength
-    end_struct
+struct HealingItem
+	extends Item
+	bytes Strength
+end_struct
 ```
 
 This effectively copies the members of the source struct, meaning that you can now use `HealingItem_Name` as well as `HealingItem_Strength`.
@@ -104,10 +104,10 @@ This effectively copies the members of the source struct, meaning that you can n
 If a second argument is provided, the copied members will be prefixed with this string.
 
 ```asm
-    struct SaveFile
-        longs 1, Checksum
-        extends NPC, Player
-    end_struct
+struct SaveFile
+	longs 1, Checksum
+	extends NPC, Player
+end_struct
 ```
 
 This creates constants like `SaveFile_Player_Name`.
@@ -123,7 +123,7 @@ Two additional constants are defined: `sizeof_NPC` contains the struct's total s
 
 Be careful that `dstruct` relies on all of these constants and a couple more; `dstruct` may break in unexpected ways if tampering with them, which includes `PURGE`.
 
-None of these constants are exported by default, but you can [`export` them manually](https://rgbds.gbdev.io/docs/v0.5.2/rgbasm.5/#Exporting_and_importing_symbols), or `INCLUDE` the struct definition(s) everywhere the constants are to be used.
+None of these constants are exported by default, but you can [`export` them manually](https://rgbds.gbdev.io/docs/rgbasm.5#Exporting_and_importing_symbols), or `INCLUDE` the struct definition(s) everywhere the constants are to be used.
 Since `dstruct` and family require the constants to be defined at assembling time, those macros require the former solution.
 However, the latter solution may decrease build times if you have a lot of source files.
 
@@ -136,8 +136,7 @@ If you want the constants to be exported by default, define symbol `STRUCTS_EXPO
 To allocate a struct in memory, use the `dstruct StructName, VarName` macro. For example:
 
 ```asm
-    ; Again, remember to put whitespace before the macro name
-    dstruct NPC, Player
+dstruct NPC, Player
 ```
 
 This will define the following labels: `Player` (pointing to the struct's first byte), `Player_YPos`, `Player_XPos`, `Player_YBox`, etc. (all pointing to the struct's corresponding attribute).
@@ -157,7 +156,7 @@ Like structs' constants, these are not exported unless `STRUCTS_EXPORT_CONSTANTS
 
 #### Defining data from a struct
 
-The use of `dstruct` described above makes it act like [`ds`](https://rgbds.gbdev.io/docs/v0.5.2/rgbasm.5/#Statically_allocating_space_in_RAM) (meaning, it can be used in RAM, and will be filled with padding bytes if used in ROM).
+The use of `dstruct` described above makes it act like [`ds`](https://rgbds.gbdev.io/docs/rgbasm.5#Statically_allocating_space_in_RAM) (meaning, it can be used in RAM, and will be filled with padding bytes if used in ROM).
 However, it is possible to use `dstruct` to define data without having to resort to piles of `db`s and `dw`s.
 
 ```asm

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Of particular interest is `DEF STRUCT_SEPARATOR equs "."`, which causes members 
 
 It is unnecessary to put a label right before `dstruct`, since a label is declared at the struct's root.
 
-Unless the struct's name contains a dot `.`, two extra constants are declared, that mirror the struct's: `sizeof_Player` would be equal to `sizeof_NPC`, and `Player_nb_fields` would equal `NPC_nb_fields` (sse below).
+Unless the struct's name contains a dot `.`, two extra constants are declared, that mirror the struct's: `sizeof_Player` would be equal to `sizeof_NPC`, and `Player_nb_fields` would equal `NPC_nb_fields` (see below).
 These constants will keep their values even if the originals, such as `sizeof_NPC`, are `PURGE`'d.
 Like structs' constants, these are not exported unless `STRUCTS_EXPORT_CONSTANTS` is defined.
 

--- a/examples/correct.asm
+++ b/examples/correct.asm
@@ -1,7 +1,7 @@
 INCLUDE "../structs.inc"
 
 	; Check for the expected RGBDS-structs version
-	rgbds_structs_version 4.0.2
+	rgbds_structs_version 4.1.0
 
 
 	; Struct declarations (ideally in a separate file, but grouped here for simplicity)

--- a/examples/correct.asm
+++ b/examples/correct.asm
@@ -8,7 +8,7 @@ INCLUDE "../structs.inc"
 	; Note that everything is happening outside of a `SECTION`
 
 
-	; Defines a sprite as it is in OAM
+; Defines a sprite as it is in OAM
 struct Sprite
 	bytes 1, YPos ; Indenting is optional, but recommended
 	bytes 1, XPos
@@ -16,7 +16,7 @@ struct Sprite
 	bytes 1, Attr
 end_struct
 
-	; Defines an NPC, as I used in Aevilia (https://github.com/ISSOtm/Aevilia-GB/blob/master/macros/memory.asm#L10-L25)
+; Defines an NPC, as I used in Aevilia (https://github.com/ISSOtm/Aevilia-GB/blob/master/macros/memory.asm#L10-L25)
 struct NPC
 	words 1, YPos
 	words 1, XPos
@@ -37,12 +37,18 @@ struct NPC
 	bytes 1, XDispl
 end_struct
 
-	; Defines a 3-byte CGB palette
+; Defines a 3-byte CGB palette
 struct RawPalette
 	bytes 3, Color0
 	bytes 3, Color1
 	bytes 3, Color2
 	bytes 3, Color3
+end_struct
+
+; Defines a pair of pointers
+struct Pics
+	words 1, Front
+	words 1, Back
 end_struct
 
 
@@ -95,6 +101,11 @@ Routine::
 		.Color1=$1E\,$0A\,$06, \ ; Multi-byte fields can take a
 		.Color2=$1F\,$13\,$16, \ ; sequence of bytes to repeat
 		.Color3=$1F, .Color0=$00
+
+	; Anonymous instantiation does not automatically define labels
+	Pics:: dstruct_anon Pics, .Front=.Front, .Back=.Back
+	.Front:: ds 7 * 7 * 16, $00
+	.Back::  ds 5 * 5 * 16, $00
 
 
 memcpy_small:

--- a/structs.inc
+++ b/structs.inc
@@ -23,7 +23,7 @@
 
 
 
-def STRUCTS_VERSION equs "4.0.3"
+def STRUCTS_VERSION equs "4.1.0"
 MACRO structs_assert
 	assert (\1), "rgbds-structs {STRUCTS_VERSION} bug. Please report at https://github.com/ISSOtm/rgbds-structs, and share the above stack trace *and* your code there!"
 ENDM

--- a/structs.inc
+++ b/structs.inc
@@ -277,14 +277,16 @@ MACRO dstruct ; struct_type, instance_name[, ...]
 
 		; Do the nested ordered instantiation
 		def WAS_NAMED_INSTANTIATION = 1
-		dstruct {ORDERED_ARGS} ; purges IS_NAMED_INSTANTIATION
+		dstruct {ORDERED_ARGS}, ; purges IS_NAMED_INSTANTIATION
 		purge ORDERED_ARGS, WAS_NAMED_INSTANTIATION
 
 	ELSE
 		; This is an ordered instantiation, not a named one.
 
-		; Define the struct's root label
-		\2::
+		; Define the struct's root label unless it's anonymous.
+		IF STRLEN("\2")
+			\2::
+		ENDC
 
 		IF def(STRUCT_SEPARATOR)
 			def DSTRUCT_SEPARATOR equs "{STRUCT_SEPARATOR}"
@@ -296,8 +298,15 @@ MACRO dstruct ; struct_type, instance_name[, ...]
 		FOR FIELD_ID, \1_nb_fields
 			get_nth_field_info \1, FIELD_ID
 
-			; Define the label for the field
-			\2_{{STRUCT_FIELD_NAME}}::
+			IF STRLEN("\2")
+				; Define the label for the field
+				\2_{{STRUCT_FIELD_NAME}}::
+				def STRUCT_FIELD_START EQUS "\2_{{STRUCT_FIELD_NAME}}"
+			ELSE
+				; Label the field anonymously for padding calculations
+				:
+				def STRUCT_FIELD_START EQUS ":-"
+			ENDC
 
 			IF STRUCT_FIELD_SIZE != 0 ; Skip aliases
 				; Declare the space for the field
@@ -315,18 +324,19 @@ MACRO dstruct ; struct_type, instance_name[, ...]
 				ENDC
 				; Add padding as necessary after the provided initializer
 				; (possibly all of it, especially for RAM use)
-				IF {STRUCT_FIELD_SIZE} < @ - \2_{{STRUCT_FIELD_NAME}}
-					fail STRFMT("Initializer for %s is %u bytes, expected %u at most", "\2_{{STRUCT_FIELD_NAME}}", @ - \2_{{STRUCT_FIELD_NAME}}, {STRUCT_FIELD_SIZE})
+				IF {STRUCT_FIELD_SIZE} < @ - {STRUCT_FIELD_START}
+					fail STRFMT("Initializer for %s is %u bytes, expected %u at most", "{STRUCT_FIELD_START}", @ - {STRUCT_FIELD_START}, {STRUCT_FIELD_SIZE})
 				ENDC
-				ds {STRUCT_FIELD_SIZE} - (@ - \2_{{STRUCT_FIELD_NAME}})
+				ds {STRUCT_FIELD_SIZE} - (@ - {STRUCT_FIELD_START})
 			ENDC
 
 			purge_nth_field_info
+			purge STRUCT_FIELD_START
 		ENDR
 		purge FIELD_ID, ARG_NUM, DSTRUCT_SEPARATOR
 
 		; Define instance's properties from struct's
-		IF STRFIND("\2", ".") == -1
+		IF STRLEN("\2") && STRFIND("\2", ".") == -1
 			def \2_nb_fields EQU \1_nb_fields
 			def sizeof_\2    EQU @ - (\2)
 			structs_assert sizeof_\1 == sizeof_\2
@@ -340,19 +350,34 @@ MACRO dstruct ; struct_type, instance_name[, ...]
 	ENDC
 ENDM
 
+; Allocates space for an anonymous struct in memory.
+; Acts like `dstruct` but without defining any labels for the struct or its fields.
+MACRO dstruct_anon ; struct_type[, ...]
+	def DSTRUCT_ANON_NAME EQUS "\1"
+	shift
+	dstruct {DSTRUCT_ANON_NAME}, , \#
+	purge DSTRUCT_ANON_NAME
+ENDM
+
 
 ; Allocates space for an array of structs in memory.
 ; Each struct will have the index appended to its name **as decimal**.
 ; For example: `dstructs 32, NPC, wNPC` will define `wNPC0`, `wNPC1`, and so on until `wNPC31`.
 ; This is a change from the previous version of rgbds-structs, where the index was uppercase hexadecimal.
+; If the third argument is not given, no names are defined, and the structs are anonymous.
+; For example: `dstructs 32, NPC` will repeat `dstruct_anon NPC` 32 times.
 ; Does not support data declarations because I think each struct should be defined individually for that purpose.
-MACRO dstructs ; nb_structs, struct_type, instance_name
-	IF _NARG != 3
-		fail "`dstructs` only takes 3 arguments!"
+MACRO dstructs ; nb_structs, struct_type[, instance_name]
+	IF _NARG == 2
+		REPT \1
+			dstruct_anon \2
+		ENDR
+	ELIF _NARG == 3
+		FOR STRUCT_ID, \1
+			dstruct \2, \3{d:STRUCT_ID}
+		ENDR
+		purge STRUCT_ID
+	ELSE
+		fail "Expected 2 or 3 args to `dstructs`, but got {d:_NARG}"
 	ENDC
-
-	FOR STRUCT_ID, \1
-		dstruct \2, \3{d:STRUCT_ID}
-	ENDR
-	purge STRUCT_ID
 ENDM

--- a/structs.inc
+++ b/structs.inc
@@ -316,7 +316,7 @@ MACRO dstruct ; struct_type, instance_name[, ...]
 					IF def(WAS_NAMED_INSTANTIATION)
 						; Remove the parentheses that named instantiation placed around the field initializer.
 						; This is necessary so that strings are correctly interpreted.
-						redef FIELD_INITIALIZER EQUS STRSLICE("{FIELD_INITIALIZER}", 1, -2)
+						redef FIELD_INITIALIZER EQUS STRSLICE("{FIELD_INITIALIZER}", 1, -1)
 					ENDC
 					d{{STRUCT_FIELD_TYPE}} {FIELD_INITIALIZER}
 					purge FIELD_INITIALIZER


### PR DESCRIPTION
The 0-indexed string functions like `STRSLICE` and `STRFIND` were added in RGBDS 0.9.2, so that's the new requirement.

This is a minor version bump since it introduces the `dstruct_anon` macro.